### PR TITLE
Updated append-bootstrap

### DIFF
--- a/ignition.adoc
+++ b/ignition.adoc
@@ -106,6 +106,24 @@ sed -i 's/mastersSchedulable: true/mastersSchedulable: false/g' manifests/cluste
 ----
 
 Create ignition configs:
+
+For OCP version 4.6 or newer, you should use this one:
+----
+{
+  "ignition": {
+    "config": {
+      "merge": [
+        {
+          "source": "<bootstrap_ignition_config_url>" 
+        }
+      ]
+    },
+    "version": "3.1.0"
+  }
+}
+----
+
+For older versions, you should use this one:
 ----
 openshift-install create ignition-configs
 


### PR DESCRIPTION
For OCP 4.6 and newer, a new version of append-bootstrap is required to fit RHCOS pre requisites.

https://docs.openshift.com/container-platform/4.6/installing/installing_vsphere/installing-vsphere-network-customizations.html